### PR TITLE
feat: add one-time check for printk symbol and support for _printk

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,9 @@ using namespace BinaryNinja;
 extern "C" {
 BN_DECLARE_CORE_ABI_VERSION;
 
+static Ref<Symbol> sym = nullptr;
+static std::mutex g_initialAnalysisMutex;
+
 // Backwards map the KERN_* log level macros (or at least the second byte of
 // them) We expect caller to pass us the byte after the SOH byte. Returns either
 // a string or NULL if unknown.
@@ -42,15 +45,25 @@ void PrintkFixerMLIL(Ref<AnalysisContext> analysisContext) {
       analysisContext->GetMediumLevelILFunction();
   Ref<BinaryView> bv = analysisContext->GetFunction()->GetView();
 
-  // If we don't find printk, this probably isn't a kernel module...
-  // TODO: don't re-find this every time the Binary Ninja core calls us.
-  auto sym = bv->GetSymbolByRawName("printk");
-  if (!sym) {
-    LogWarn(
-        "Failed to find printk: PrintkFixer won't do anything (is this a Linux "
-        "kernel module?)");
-    return;
+  // The scoped_lock allows us to lock all analysis threads to have only 1
+  // thread search for the symbol reference to printk.
+  {
+    std::scoped_lock<std::mutex> lock(g_initialAnalysisMutex);
+    if (!bv->HasInitialAnalysis()) {
+      sym = bv->GetSymbolByRawName("printk");
+      // Linux kernels after 5.15 use a printk indexing system which changed the
+      // exported `printk` symbol into `_printk`.
+      if (!sym) sym = bv->GetSymbolByRawName("_printk");
+      if (!sym)
+        LogWarn(
+            "Failed to find printk: PrintkFixer won't do anything (is this a "
+            "Linux kernel module?)");
+    }
   }
+
+  // Early return if the symbol could not be found.
+  if (!sym) return;
+
   uint64_t printkAddr = sym->GetAddress();
   // LogDebug("Printk is at %zx", printkAddr);
 


### PR DESCRIPTION
A one-time check for the printk symbol has been added. This is done with a check to the `HasInitialAnalysis()` function and a `std::scoped_lock<std::mutex>` to halt all the analysis threads to allow a single thread to perform the symbol check instead of all threads performing the check simultaneously.

There is also an additional call to `GetSymbolByRawName()` for the new exported printk symbol, `_printk` which was introduced in the following linux kernel commit(https://github.com/torvalds/linux/commit/337015573718b161891a3473d25f59273f2e626b). Kernel versions from v5.15 and onwards will use this symbol.